### PR TITLE
Make disabled buttons unclickable - fixes #44

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -145,6 +145,7 @@
 	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-disabled
 	// This is a common style for all button themes
 	&[disabled] {
+		pointer-events: none;
 		opacity: 0.4;
 		cursor: default;
 	}


### PR DESCRIPTION
Fixes #44 

Fixes a bug where disabled anchors would still receive active state styles on click.